### PR TITLE
Switch to testing image to enable Python 3.9

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,6 +1,9 @@
 # Required
 version: 2
 
+build:
+  image: testing
+
 python:
   version: 3.9
   install:


### PR DESCRIPTION
In line with https://github.com/python/peps/issues/2#issuecomment-870976924 :)